### PR TITLE
[CLOUD-1963] bump activemq-rar version

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -233,8 +233,8 @@ artifacts:
       md5: 7681e42eda03d9ad990fbe39c96677a4
     - path: oauth-20100527.jar
       md5: 91c7c70579f95b7ddee95b2143a49b41
-    - url: https://maven.repository.redhat.com/ga/org/apache/activemq/activemq-rar/5.11.0.redhat-630262/activemq-rar-5.11.0.redhat-630262.rar
-      md5: d0c70b9b2da1f02473d52f59d1d14b0b
+    - url: https://maven.repository.redhat.com/ga/org/apache/activemq/activemq-rar/5.11.0.redhat-630310/activemq-rar-5.11.0.redhat-630310.rar
+      sha256: ebc2d23c9207fa73cc3908abec2316dce3adbdfbbe88f6f3d7490ec22def747c
     - path: hawkular-javaagent-1.0.0.CR5-redhat-1-shaded.jar
       md5: f5d3e0220e10c706ef86af84771cf74e
     - path: rh-sso-7.1.0-eap6-adapter.zip


### PR DESCRIPTION
To resolve https://issues.jboss.org/browse/CLOUD-1963

This upgrades the internal Spring version to 3.2.18, fixing
CVE-2016-9878