### PR TITLE
eap64-dev branch to refer eap64-dev in jboss-eap-6-image

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -36,7 +36,7 @@ modules:
           - name: jboss-eap-6-image
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-6-image.git
-                  ref: eap64
+                  ref: eap64-dev
       install:
           - name: jboss.container.openjdk.jdk
             version: "8"


### PR DESCRIPTION
branch eap64-dev should contain the reference to eap64-dev from jboss-eap-6-image. for example current set up makes trouble to build as there is no 'eap-6.4-latest' module

/cc @luck3y 