### PR TITLE
[CLOUD-3141] adding dependency to os-eap-txrecovery:python2 module

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -71,6 +71,8 @@ modules:
           - name: os-logging
           - name: jboss.container.eap.prometheus.config
             version: '6.4'
+          - name: os-eap-txnrecovery.run
+            version: 'python2'
 packages:
       content_sets_file: content_sets.yml
       install:


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3141

txnrecovery module moved to versioning python version to be used and needs to be referred in the image.yaml