### PR TITLE
[CLOUD-3192] Update cp-overrrides to version 6.4.22-1

### DIFF
--- a/cp-overrides.yaml
+++ b/cp-overrides.yaml
@@ -7,7 +7,7 @@ modules:
           - name: jboss-eap-modules
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules
-                  ref: sprint-28
+                  ref: 6.4.22-1
           - name: jboss-eap-6-image
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-6-image.git


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3192
Signed-off-by: Roberto Oliveira rguimara@redhat.com