### PR TITLE
[CLOUD-3684] update references to jboss-eap-modules in cp-overrides.yaml

### DIFF
--- a/cp-overrides.yaml
+++ b/cp-overrides.yaml
@@ -7,7 +7,7 @@ modules:
           - name: jboss-eap-modules
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules
-                  ref: 6.4.23-1
+                  ref: 6.4.23-2
           - name: jboss-eap-6-image
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-6-image.git


### PR DESCRIPTION
After metadata update of narayana, the jboss-eap-modules had to be re-tagged.
This commit updates the references to it.

Signed-off-by: Daniel Kreling <dkreling@redhat.com>
